### PR TITLE
Prompt user with correct date format.

### DIFF
--- a/broadgauge/templates/workshops/edit.html
+++ b/broadgauge/templates/workshops/edit.html
@@ -9,7 +9,7 @@
       {{ render_field(form.title, help="E.g. Introduction to Python programming") }}
       {{ render_field(form.description, help="Please provide details about duration, requirements, level of participants etc.") }}
       {{ render_field(form.expected_participants) }}
-      {{ render_field(form.date, type="date") }}
+      {{ render_field(form.date, type="date", help="Provide date in format YYYY-MM-DD", placeholder="YYYY-MM-DD") }}
 
       <button type="submit" class="btn btn-default">Submit</button>
     </form>

--- a/broadgauge/templates/workshops/new.html
+++ b/broadgauge/templates/workshops/new.html
@@ -9,7 +9,7 @@
       {{ render_field(form.title, help="E.g. Introduction to Python programming") }}
       {{ render_field(form.description, help="Please provide details about duration, requirements, level of participants etc.") }}
       {{ render_field(form.expected_participants) }}
-      {{ render_field(form.date, type="date") }}
+      {{ render_field(form.date, type="date", help="Provide date in format YYYY-MM-DD", placeholder="YYYY-MM-DD") }}
 
       <button type="submit" class="btn btn-default">Submit</button>
     </form>


### PR DESCRIPTION
Has a long description in the small-print "help" area, as well as using
the placeholder to provide a hint within the text area itself, in case
people skipped over the help text.

Fixes PythonIreland/broadgauge#3
